### PR TITLE
Upgrade actions/checkout and docker/login-action v2 -> v3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: "Set image version"
       id: set-image-tag
       run: |
@@ -19,7 +19,7 @@ jobs:
         echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
         echo "image=${BASEIMAGE}:${IMAGE_TAG}" >> ${GITHUB_OUTPUT}
     - name: Login to GitHub Packages Docker Registry
-      uses: docker/login-action@ab80d026d4753220c4243394c07c7d80f9638d06 # Use commit-sha1 instead of tag for security concerns
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # Use commit-sha1 instead of tag for security concerns
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
           - dev-gcp
           - prod-gcp
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: nais/deploy/actions/deploy@v1
         name: Deploy topic collector
         env:
@@ -62,7 +62,7 @@ jobs:
           - dev-gcp
           - prod-gcp
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: nais/deploy/actions/deploy@v1
         name: Deploy to ${{ matrix.cluster }}
         env:
@@ -81,7 +81,7 @@ jobs:
           - dev-fss
           - prod-fss
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: nais/deploy/actions/deploy@v1
         name: Deploy to ${{ matrix.cluster }}
         env:
@@ -95,7 +95,7 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: nais/deploy/actions/deploy@v1
         name: Deploy topic and persist application to prod-gcp
         env:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/