### PR TITLE
navikt/baseimages no longer publishes to dockerhub

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -42,7 +42,7 @@ tests:
         poetry run pytest
 
 docker:
-    FROM navikt/python:${PY_VERSION}
+    FROM ghcr.io/navikt/baseimages/python:${PY_VERSION}
     WORKDIR /app
 
     # Ensure images are pushed to cache for these targets


### PR DESCRIPTION
... will use ghcr after navikt/baseimages#148 is merged

Merge this once that is merged.